### PR TITLE
Add ad-hoc code signing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,11 @@ jobs:
           mkdir -p build/export
           cp -R build/uguisu.xcarchive/Products/Applications/uguisu.app build/export/
 
+      - name: Ad-hoc code sign
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          codesign --force --deep --sign - build/export/uguisu.app
+
       - name: Create zip
         if: steps.check_tag.outputs.exists == 'false'
         run: |


### PR DESCRIPTION
## Summary
- リリースワークフローにad-hoc署名のステップを追加
- ビルド後のアプリに `codesign --force --deep --sign -` で自己署名を適用

## Test plan
- [ ] PRマージ後、リリースワークフローが正常に実行されることを確認
- [ ] リリースされたzipをダウンロードして署名を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)