### PR TITLE
fix: Add workflow_dispatch to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build-and-release:


### PR DESCRIPTION
## Related Issue
N/A

## User Request / AI Reasoning
- v0.0.6リリースが作成されていない問題に対する応急処置
- GitHub Actionsはワークフロー内からの`git push`では無限ループ防止のため新しいワークフローをトリガーしない
- そのため、リリースワークフロー内でVERSIONをバンプしてpushした後、そのコミットでリリースワークフローが実行されなかった
- `workflow_dispatch`を追加することで、手動でもリリースワークフローを実行可能にする

**注意**: この変更は自動化の問題を解決するものではなく、手動でワークフローを実行可能にするのみです。

**TODO**: 根本的な解決には、PATを使用したpushまたはワークフロー構造の変更が必要です（後続Issueで対応）。

## Changes
- `.github/workflows/release.yml`に`workflow_dispatch`トリガーを追加

## Verification
- [x] `workflow_dispatch`トリガーが追加されたことを確認
- [ ] このPRマージ後、手動でワークフローを実行してv0.0.6がリリースされることを確認
- [ ] Issue作成: VERSIONバンプ後の自動リリース作成を実現する恒久的な解決策を検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)